### PR TITLE
fix: Updated metal-go client for sub-commands gateways

### DIFF
--- a/internal/gateway/delete.go
+++ b/internal/gateway/delete.go
@@ -21,6 +21,7 @@
 package gateway
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/manifoldco/promptui"
@@ -34,7 +35,7 @@ func (c *Client) Delete() *cobra.Command {
 	)
 
 	deleteGway := func(id string) error {
-		_, err := c.Service.Delete(id)
+		_, _, err := c.Service.DeleteMetalGateway(context.Background(), gwayID).Execute()
 		if err != nil {
 			return err
 		}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -21,14 +21,14 @@
 package gateway
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	"github.com/equinix/metal-cli/internal/outputs"
-	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 )
 
 type Client struct {
 	Servicer Servicer
-	Service  packngo.MetalGatewayService
+	Service  metal.MetalGatewaysApiService
 	Out      outputs.Outputer
 }
 
@@ -45,7 +45,7 @@ func (c *Client) NewCommand() *cobra.Command {
 					root.PersistentPreRun(cmd, args)
 				}
 			}
-			c.Service = c.Servicer.API(cmd).MetalGateways
+			c.Service = *c.Servicer.MetalAPI(cmd).MetalGatewaysApi
 		},
 	}
 
@@ -58,8 +58,11 @@ func (c *Client) NewCommand() *cobra.Command {
 }
 
 type Servicer interface {
-	API(*cobra.Command) *packngo.Client
-	ListOptions(defaultIncludes, defaultExcludes []string) *packngo.ListOptions
+	MetalAPI(*cobra.Command) *metal.APIClient
+	Format() outputs.Format
+	Filters() map[string]string
+	Includes(defaultIncludes []string) (incl []string)
+	Excludes(defaultExcludes []string) (excl []string)
 }
 
 func NewClient(s Servicer, out outputs.Outputer) *Client {

--- a/internal/gateway/retrieve.go
+++ b/internal/gateway/retrieve.go
@@ -21,6 +21,7 @@
 package gateway
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -42,22 +43,23 @@ func (c *Client) Retrieve() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			listOpts := c.Servicer.ListOptions(nil, nil).Including("virtual_network", "ip_reservation")
-			gways, _, err := c.Service.List(projectID, listOpts)
+			inc := []string{"virtual_network", "ip_reservation"}
+			exc := []string{}
+			gwaysList, err := c.Service.FindMetalGatewaysByProject(context.Background(), projectID).Include(c.Servicer.Includes(inc)).Exclude(c.Servicer.Excludes(exc)).ExecuteWithPagination()
 			if err != nil {
 				return fmt.Errorf("Could not list Project Metal Gateways: %w", err)
 			}
-
+			gways := gwaysList.GetMetalGateways()
 			data := make([][]string, len(gways))
 
 			for i, n := range gways {
 				address := ""
 
-				if n.IPReservation != nil {
-					address = n.IPReservation.Address + "/" + strconv.Itoa(n.IPReservation.CIDR)
+				if n.MetalGateway.IpReservation != nil {
+					address = n.MetalGateway.IpReservation.GetAddress() + "/" + strconv.Itoa(int(n.MetalGateway.IpReservation.GetCidr()))
 				}
 
-				data[i] = []string{n.ID, n.VirtualNetwork.MetroCode, strconv.Itoa(n.VirtualNetwork.VXLAN), address, string(n.State), n.CreatedAt}
+				data[i] = []string{n.MetalGateway.GetId(), n.MetalGateway.VirtualNetwork.GetMetroCode(), strconv.Itoa(int(n.MetalGateway.VirtualNetwork.GetVxlan())), address, string(n.MetalGateway.GetState()), n.MetalGateway.CreatedAt.String()}
 			}
 			header := []string{"ID", "Metro", "VXLAN", "Addresses", "State", "Created"}
 


### PR DESCRIPTION
Breakout from https://github.com/equinix/metal-cli/pull/270

What this PR does / why we need it:

This PR replaces packngo with metal-go for all interactions with the Equinix Metal API specifically for gateways sub commands

DISCUSSION POINTS: