### PR TITLE
feat: metal gateway get -i <id>

### DIFF
--- a/docs/metal_gateway_get.md
+++ b/docs/metal_gateway_get.md
@@ -7,7 +7,7 @@ Lists Metal Gateways.
 Retrieves a list of all VLANs for the specified project.
 
 ```
-metal gateway get -p <project_UUID> [flags]
+metal gateway get [-p <project_UUID>] [-i <gateway_UUID>] [flags]
 ```
 
 ### Examples
@@ -16,12 +16,16 @@ metal gateway get -p <project_UUID> [flags]
 
   # Lists Metal Gateways for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
   metal gateways get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c
+  
+  # Gets a Metal Gateway with ID 8404b73c-d18f-4190-8c49-20bb17501f88:
+  metal gateways get -i 8404b73c-d18f-4190-8c49-20bb17501f88
 ```
 
 ### Options
 
 ```
   -h, --help                help for get
+  -i, --id string           The UUID of a gateway.
   -p, --project-id string   The project's UUID. This flag is required, unless specified in the config created by metal init or set as METAL_PROJECT_ID environment variable.
 ```
 


### PR DESCRIPTION
Adds `metal gateway get -i`:

```console
$ go run ./cmd/metal/ gateways get  -i $METAL_GATEWAY_ID                   
+--------------------------------------+-------+-------+------------------+--------+-------------------------------+-------------------+
|                  ID                  | METRO | VXLAN |    ADDRESSES     | STATE  |            CREATED            |        VRF        |
+--------------------------------------+-------+-------+------------------+--------+-------------------------------+-------------------+
| bd3162f4-4162-408b-8670-f70782fe763e | am    | 1002  | 192.168.100.2/22 | active | 2024-08-02 18:16:23 +0000 UTC | nutanix-vrf-bRkYc |
+--------------------------------------+-------+-------+------------------+--------+-------------------------------+-------------------+
```

```console
$ go run ./cmd/metal/ gateways get  -p $METAL_PROJECT_ID 
+--------------------------------------+-------+-------+------------------+--------+-------------------------------+-------------------+
|                  ID                  | METRO | VXLAN |    ADDRESSES     | STATE  |            CREATED            |        VRF        |
+--------------------------------------+-------+-------+------------------+--------+-------------------------------+-------------------+
| bd3162f4-4162-408b-8670-f70782fe763e | am    | 1002  | 192.168.100.2/22 | active | 2024-08-02 18:16:23 +0000 UTC | nutanix-vrf-bRkYc |
+--------------------------------------+-------+-------+------------------+--------+-------------------------------+-------------------+
```

After unsettling project id in ~/.config/equinix/metal.yaml:
```console
$ go run ./cmd/metal/ gateways get 
Error: either id or project-id should be set
Usage:
  metal gateway get [-p <project_UUID>] [-i <gateway_UUID>] [flags]

Aliases:
  get, list

Examples:

  # Lists Metal Gateways for project 3b0795ba-ec9a-4a9e-83a7-043e7e11407c:
  metal gateways get -p 3b0795ba-ec9a-4a9e-83a7-043e7e11407c
  
  # Gets a Metal Gateway with ID 8404b73c-d18f-4190-8c49-20bb17501f88:
  metal gateways get -i 8404b73c-d18f-4190-8c49-20bb17501f88

Flags:
  -h, --help                help for get
  -i, --id string           The UUID of a gateway.
  -p, --project-id string   The project's UUID. This flag is required, unless specified in the config created by metal init or set as METAL_PROJECT_ID environment variable.

Global Flags:
...
```