### PR TITLE
chore: include community badge and remove slack references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,6 @@ labels: bug
 Thank you for helping to improve the CLI!
 Please be sure to search for open issues before raising a new one.
 We use issues for bug reports and feature requests.
-Please find us at https://slack.equinixmetal.com for questions and discussion.
 -->
 
 ### What happened?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,6 @@ Thank you for helping to improve the CLI!
 
 Please be sure to search for open issues before raising a new one.
 We use issues for bug reports and feature requests.
-Please find us at https://slack.equinixmetal.com for questions and discussion.
 -->
 
 ### What problem are you facing?

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![GitHub release](https://img.shields.io/github/release/equinix/metal-cli/all.svg?style=flat-square)](https://github.com/equinix/metal-cli/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/equinix/metal-cli)](https://goreportcard.com/report/github.com/equinix/metal-cli)
-[![Slack](https://slack.equinixmetal.com/badge.svg)](https://slack.equinixmetal.com)
-[![Twitter Follow](https://img.shields.io/twitter/follow/equinixmetal.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=equinixmetal)
+[![Equinix Community](https://img.shields.io/badge/Equinix%20Community%20-%20%23E91C24?logo=equinixmetal)](https://community.equinix.com)
 
 ## Table of Contents
 
@@ -272,4 +271,3 @@ Details on all available commands can be found by visiting the reference [pages]
 For help with this package:
 
 - Open up a GitHub issue [here](https://github.com/equinix/metal-cli/issues).
-- Contact the [Equinix Metal Community Slack](http://slack.equinixmetal.com).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,3 +1,0 @@
-If you require support, please email support@equinixmetal.com, subscribe to the [Equinix Metal Community Slack](https://slack.equinixmetal.com/) channel or post an issue within this repository.
-
-[Contributions](CONTRIBUTING.md) are welcome to help extend this work!


### PR DESCRIPTION
following suite with the [terraform repo](https://github.com/equinix/terraform-provider-equinix) i've also added an Equinix Community badge to this readme and removed the X badge (we don't use it any longer).

I also removed the SUPPORT.md per @ctreatma's suggestion and deleted a few other references to the Slack instance.