### PR TITLE
chore: update tag for checkout gha

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
We want to trigger renovate to update all the github actions sha commits.