### PR TITLE
chore: Update semantic-release-action tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           go-version-file: go.mod
       - name: Release
         id: semantic-release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v4.2.2
         with:
           semantic_version: 24.0.0
           extra_plugins: |


### PR DESCRIPTION
To allow renovate to pick the correct tag for a gha.