### PR TITLE
feat: Deprecate flags for creating spot market instances

### DIFF
--- a/docs/metal_device_create.md
+++ b/docs/metal_device_create.md
@@ -36,8 +36,6 @@ metal device create -p <project_id> (-m <metro> | -f <facility>) -P <plan> -H <h
   -P, --plan string                      Name of the plan
   -p, --project-id string                The project's UUID. This flag is required, unless specified in the config created by metal init or set as METAL_PROJECT_ID environment variable.
   -S, --public-ipv4-subnet-size int      Size of the public IPv4 subnet.
-  -s, --spot-instance                    Provisions the device as a spot instance.
-      --spot-price-max float             Sets the maximum spot market price for the device: --spot-price-max=1.2
   -t, --tags strings                     Tag or list of tags for the device: --tags="tag1,tag2".
   -T, --termination-time string          Device termination time: --termination-time="2023-08-24T15:04:05Z"
   -u, --userdata string                  Userdata for device initialization. Can not be used with --userdata-file.

--- a/internal/devices/create.go
+++ b/internal/devices/create.go
@@ -224,5 +224,8 @@ func (c *Client) Create() *cobra.Command {
 	createDeviceCmd.Flags().Float64VarP(&spotPriceMax, "spot-price-max", "", 0, `Sets the maximum spot market price for the device: --spot-price-max=1.2`)
 	createDeviceCmd.Flags().StringVarP(&terminationTime, "termination-time", "T", "", `Device termination time: --termination-time="2023-08-24T15:04:05Z"`)
 
+	_ = createDeviceCmd.Flags().MarkDeprecated("spot-instance", "spot market is no longer available")
+	_ = createDeviceCmd.Flags().MarkDeprecated("spot-price-max", "spot market is no longer available")
+
 	return createDeviceCmd
 }


### PR DESCRIPTION
This just marks the spot-market related flags as deprecated as the API no longer accepts requests for spot instances.

More info can be found here: https://docs.equinix.com/metal/#retiring-spot-market